### PR TITLE
Don't update NPM to latest version; use the version bundled with the io.js release

### DIFF
--- a/1.0/Dockerfile
+++ b/1.0/Dockerfile
@@ -13,15 +13,12 @@ RUN apt-get update && apt-get install -y \
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys C273792F7D83545D
 
 ENV IOJS_VERSION 1.0.2
-ENV NPM_VERSION 2.2.0
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \
   && gpg --verify SHASUMS256.txt.asc \
   && grep " iojs-v$IOJS_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
   && tar -xzf "iojs-v$IOJS_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-  && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
-  && npm install -g npm@"$NPM_VERSION" \
-  && npm cache clear
+  && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
 CMD [ "iojs" ]

--- a/1.0/slim/Dockerfile
+++ b/1.0/slim/Dockerfile
@@ -14,15 +14,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys C273792F7D83545D
 
 ENV IOJS_VERSION 1.0.2
-ENV NPM_VERSION 2.2.0
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \
   && gpg --verify SHASUMS256.txt.asc \
   && grep " iojs-v$IOJS_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
   && tar -xzf "iojs-v$IOJS_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-  && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
-  && npm install -g npm@"$NPM_VERSION" \
-  && npm cache clear
+  && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
 CMD [ "iojs" ]

--- a/update.sh
+++ b/update.sh
@@ -9,14 +9,12 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
-npmVersion="$(docker run --rm iojs/iojs npm show npm version)"
 for version in "${versions[@]}"; do
   fullVersion="$(curl -sSL --compressed 'https://iojs.org/dist' | grep '<a href="v'"$version." | sed -r 's!.*<a href="v([^"/]+)/?".*!\1!' | sort -V | tail -1)"
   (
     set -x
     sed -ri '
       s/^(ENV IOJS_VERSION) .*/\1 '"$fullVersion"'/;
-      s/^(ENV NPM_VERSION) .*/\1 '"$npmVersion"'/;
     ' "$version/Dockerfile" "$version/slim/Dockerfile"
     sed -ri 's/^(FROM iojs\/iojs):.*/\1:'"$fullVersion"'/' "$version/onbuild/Dockerfile"
   )


### PR DESCRIPTION
The original Node.js image updated NPM to the latest version available (detected via the `update.sh` script). This made sense for Node, which had rare releases. For io.js it doesn't seem so useful. We should probably trust and use the NPM version bundled in the io.js release. This pull request removes the "update NPM" functionality.

Thoughts?
