### PR TITLE
Prepare for image becoming official (change links, image id, etc.)

### DIFF
--- a/1.0/onbuild/Dockerfile
+++ b/1.0/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM iojs/iojs:1.0
+FROM iojs:1.0.2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -1,19 +1,12 @@
-iojs/iojs
+iojs
 =========
 
-[![dockeri.co](http://dockeri.co/image/iojs/iojs)](https://registry.hub.docker.com/u/iojs/iojs/)
+[![dockeri.co](http://dockeri.co/image/_/iojs)](https://registry.hub.docker.com/_/iojs/)
 
 [![issues](https://img.shields.io/github/issues/iojs/docker-iojs.svg) ![starts](https://img.shields.io/github/stars/iojs/docker-iojs.svg)](https://github.com/iojs/docker-iojs)
 
 
 The official iojs docker image, made with love by the iojs community.
-
-## Supported tags
-*and respective Dockerfile links*
-
-* [`1.0` `latest` (1.0/Dockerfile)](https://github.com/iojs/docker-iojs/blob/master/1.0/Dockerfile)
-* [`1.0-onbuild` `onbuild` (1.0/onbuild/Dockerfile)](https://github.com/iojs/docker-iojs/blob/master/1.0/onbuild/Dockerfile)
-* [`1.0-slim` `slim` (1.0/slim/Dockerfile)](https://github.com/iojs/docker-iojs/blob/master/1.0/slim/Dockerfile)
 
 ## What is iojs?
 *from [iojs.org/faq.html](https://iojs.org/faq.html)*
@@ -29,7 +22,7 @@ This project aims to continue development of io.js under an "open governance mod
 If you want to distribute your application on the docker registry, create a `Dockerfile` in the root of application directory:
 
 ```
-FROM iojs/iojs:onbuild
+FROM iojs:onbuild
 
 # Expose the ports that your app uses. In Example:
 EXPOSE 8080
@@ -46,5 +39,5 @@ $ docker run --rm -it iojs-app
 To run a single script, you can mount it in a volume under `/usr/src/app`. From the root of your application directory (assuming your script is named `index.js`):
 
 ```
-$ docker run -v ${PWD}:/usr/src/app -w /usr/src/app --it --rm iojs/iojs iojs index.js
+$ docker run -v ${PWD}:/usr/src/app -w /usr/src/app --it --rm iojs iojs index.js
 ```

--- a/update.sh
+++ b/update.sh
@@ -16,6 +16,6 @@ for version in "${versions[@]}"; do
     sed -ri '
       s/^(ENV IOJS_VERSION) .*/\1 '"$fullVersion"'/;
     ' "$version/Dockerfile" "$version/slim/Dockerfile"
-    sed -ri 's/^(FROM iojs\/iojs):.*/\1:'"$fullVersion"'/' "$version/onbuild/Dockerfile"
+    sed -ri 's/^(FROM iojs):.*/\1:'"$fullVersion"'/' "$version/onbuild/Dockerfile"
   )
 done


### PR DESCRIPTION
If/when the image becomes "docker official", some links/ids will have to change. Also, the "Supported tags" README section will be obsolete, as it will be auto-generated in `docker-library/docs`. This pull request prepares for when this happens.
