### PR TITLE
Optimize `slim` variant

### DIFF
--- a/1.1/slim/Dockerfile
+++ b/1.1/slim/Dockerfile
@@ -1,13 +1,4 @@
-FROM debian:jessie
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates \
-      curl \
-      build-essential \
-      pkg-config \
-      git \
-      python \
-  && rm -rf /var/lib/apt/lists/*
+FROM buildpack-deps:jessie-curl
 
 # gpg keys listed at https://github.com/iojs/io.js
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B DD8F2338BAE7501E3DD5AC78C273792F7D83545D


### PR DESCRIPTION
Proposing this as an alternative to #10. Also related to #9.

TL;DR: There now exist `buildpack-deps:curl` images, which are simply `debian`+`ca-certificates`+`curl`+`wget`. Seems like a natural base for `slim`.
