### PR TITLE
Run as a non-privileged user by default

### DIFF
--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -14,4 +14,4 @@ RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x6
   && tar -xzf "iojs-v$IOJS_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
-CMD [ "su", "-c", "\"iojs\"", "app" ]
+CMD [ "su", "-c", "iojs", "app" ]

--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -1,5 +1,7 @@
 FROM buildpack-deps:jessie
 
+RUN groupadd --gid 25000 app && useradd --uid 25000 --gid 25000 --create-home --shell /bin/bash app
+
 # gpg keys listed at https://github.com/iojs/io.js
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B DD8F2338BAE7501E3DD5AC78C273792F7D83545D
 
@@ -12,4 +14,4 @@ RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x6
   && tar -xzf "iojs-v$IOJS_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
-CMD [ "iojs" ]
+CMD [ "su", "-c", "\"iojs\"", "app" ]

--- a/1.2/onbuild/Dockerfile
+++ b/1.2/onbuild/Dockerfile
@@ -7,4 +7,4 @@ ONBUILD COPY package.json /usr/src/app/
 ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app
 
-CMD [ "npm", "start" ]
+CMD [ "su", "-c", "\"npm start\"", "app" ]

--- a/1.2/onbuild/Dockerfile
+++ b/1.2/onbuild/Dockerfile
@@ -7,4 +7,4 @@ ONBUILD COPY package.json /usr/src/app/
 ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app
 
-CMD [ "su", "-c", "\"npm start\"", "app" ]
+CMD [ "su", "-c", "npm start", "app" ]

--- a/1.2/slim/Dockerfile
+++ b/1.2/slim/Dockerfile
@@ -14,4 +14,4 @@ RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x6
   && tar -xzf "iojs-v$IOJS_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
-CMD [ "su", "-c", "\"iojs\"", "app" ]
+CMD [ "su", "-c", "iojs", "app" ]

--- a/1.2/slim/Dockerfile
+++ b/1.2/slim/Dockerfile
@@ -1,5 +1,7 @@
 FROM buildpack-deps:jessie-curl
 
+RUN groupadd --gid 25000 app && useradd --uid 25000 --gid 25000 --create-home --shell /bin/bash app
+
 # gpg keys listed at https://github.com/iojs/io.js
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B DD8F2338BAE7501E3DD5AC78C273792F7D83545D
 
@@ -12,4 +14,4 @@ RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x6
   && tar -xzf "iojs-v$IOJS_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
-CMD [ "iojs" ]
+CMD [ "su", "-c", "\"iojs\"", "app" ]


### PR DESCRIPTION
This is a proposal for resolving #23. It does two things:
1. A non-privileged user called `app` is created in all images. The user is explicitly created with high `uid` and `gid`, in order to make collisions with the host improbable.
2. The default `CMD` commands are changed to execute as `app` instead of `root` (using `su -c ...`). This matters most for `onbuild`, which is most likely to use the default command, but is also useful in the other variants (as an example for proper invocation).

I decided not to use `USER app` for changing the user, because that would have unwanted side effects and would likely break many derivative images. For example, derivatives would have to change back to `USER root` in order to install additional distro packages.

There is one caveat with this change. Apps can no longer write inside their src directory by default (as it is owned by `root`). IMHO this is a feature, not a bug - apps should not be able to modify their own source. They should use `/home/app` for storage instead, or a volume, or another location with explicitly set permissions.
