### PR TITLE
Add Dockerfile syntax highlighting to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project aims to continue development of io.js under an "open governance mod
 
 If you want to distribute your application on the docker registry, create a `Dockerfile` in the root of application directory:
 
-```
+```Dockerfile
 FROM iojs:onbuild
 
 # Expose the ports that your app uses. In Example:


### PR DESCRIPTION
GitHub has support for `Dockerfile` syntax highlighting now, so I updated the example code on the README.
