### PR TITLE
Set loglevel to notice when installing npm packages

### DIFF
--- a/1.5/onbuild/Dockerfile
+++ b/1.5/onbuild/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install
+ONBUILD RUN npm install --loglevel info
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
This PR sets [`--loglevel`](https://docs.npmjs.com/misc/config#loglevel) to `notice` when installing npm packages in the `ONBUILD` image.

**Rationale:**

Packages breaks from time to time. By default npm has `--loglevel` set to `warning` when installing, and if the install fails for some reason the entire log is written to `npm-debug.log`. If you have not mounted `/usr/src/app` as a volume this file is now _inside_ of the container which just exited.

In order to view the log you will have to copy the file from the docker container onto you host using the `docker cp` command. In my opinion this creates unnecessary overhead, and may not be entirely intuitive to novices.
