### PR TITLE
Add npm loglevel environment variable

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -3,6 +3,7 @@ FROM buildpack-deps:jessie
 # gpg keys listed at https://github.com/iojs/io.js
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B DD8F2338BAE7501E3DD5AC78C273792F7D83545D
 
+ENV NPM_CONFIG_LOGLEVEL info
 ENV IOJS_VERSION 1.5.1
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \

--- a/1.5/onbuild/Dockerfile
+++ b/1.5/onbuild/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install --loglevel info
+ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]

--- a/1.5/slim/Dockerfile
+++ b/1.5/slim/Dockerfile
@@ -3,6 +3,7 @@ FROM buildpack-deps:jessie-curl
 # gpg keys listed at https://github.com/iojs/io.js
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B DD8F2338BAE7501E3DD5AC78C273792F7D83545D
 
+ENV NPM_CONFIG_LOGLEVEL info
 ENV IOJS_VERSION 1.5.1
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \


### PR DESCRIPTION
This PR reverts #36 and adds `NPM_CONFIG_LOGLEVEL` environment variable according to discussion in docker-library/official-images#543.
