### PR TITLE
Update to v1.6.4

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -4,7 +4,7 @@ FROM buildpack-deps:jessie
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B DD8F2338BAE7501E3DD5AC78C273792F7D83545D
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV IOJS_VERSION 1.6.3
+ENV IOJS_VERSION 1.6.4
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \

--- a/1.6/onbuild/Dockerfile
+++ b/1.6/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM iojs:1.6.3
+FROM iojs:1.6.4
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/1.6/slim/Dockerfile
+++ b/1.6/slim/Dockerfile
@@ -4,7 +4,7 @@ FROM buildpack-deps:jessie-curl
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B DD8F2338BAE7501E3DD5AC78C273792F7D83545D
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV IOJS_VERSION 1.6.3
+ENV IOJS_VERSION 1.6.4
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
This PR updates the installed io.js version in all Dockerfiles to v1.6.4.

Related: iojs/io.js#1340
