### PR TITLE
Add io.js v2.0.0-rc-3

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -1,0 +1,18 @@
+FROM buildpack-deps:jessie
+
+# gpg keys listed at https://github.com/iojs/io.js
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
+  9554F04D7259F04124DE6B476D5A82AC7E37093B \
+  DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  FD3A5288F042B6850C66B31F09FE44734EB7990E
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV IOJS_VERSION 2.0.0-nightly20150504f34b105ccd
+
+RUN curl -SLO "https://iojs.org/download/nightly/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
+  && curl -SLO "https://iojs.org/download/nightly/v$IOJS_VERSION/SHASUMS256.txt" \
+  && grep " iojs-v$IOJS_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xzf "iojs-v$IOJS_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+  && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt
+
+CMD [ "iojs" ]

--- a/2.0/README.md
+++ b/2.0/README.md
@@ -1,0 +1,1 @@
+README.md

--- a/2.0/docker-compose.yml
+++ b/2.0/docker-compose.yml
@@ -1,0 +1,7 @@
+iojs2:
+    build: .
+    command: iojs --version
+
+iojs2slim:
+    build: slim
+    command: iojs --version

--- a/2.0/onbuild/Dockerfile
+++ b/2.0/onbuild/Dockerfile
@@ -1,0 +1,10 @@
+FROM iojs:2.0.0
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY package.json /usr/src/app/
+ONBUILD RUN npm install
+ONBUILD COPY . /usr/src/app
+
+CMD [ "npm", "start" ]

--- a/2.0/slim/Dockerfile
+++ b/2.0/slim/Dockerfile
@@ -1,0 +1,18 @@
+FROM buildpack-deps:jessie-curl
+
+# gpg keys listed at https://github.com/iojs/io.js
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
+  9554F04D7259F04124DE6B476D5A82AC7E37093B \
+  DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  FD3A5288F042B6850C66B31F09FE44734EB7990E
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV IOJS_VERSION 2.0.0-nightly20150504f34b105ccd
+
+RUN curl -SLO "https://iojs.org/download/nightly/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
+  && curl -SLO "https://iojs.org/download/nightly/v$IOJS_VERSION/SHASUMS256.txt" \
+  && grep " iojs-v$IOJS_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xzf "iojs-v$IOJS_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+  && rm "iojs-v$IOJS_VERSION-linux-x64.tar.gz" SHASUMS256.txt
+
+CMD [ "iojs" ]


### PR DESCRIPTION
This PR add the [release candidate](https://iojs.org/download/nightly/v2.0.0-nightly20150428509b59ea7c/) of io.js v2.0.0.

As per #51 I propose we release this version to the Docker Hub under the following tags:
- `:2`
- `:2.0`
- `:2.0.0`
- `:2.0.0-rc-1`

PR-URL: #55
Related: #51
Related: iojs/website#327
Related: iojs/io.js#1532
