### PR TITLE
Update to v2.0.2

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -7,7 +7,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   FD3A5288F042B6850C66B31F09FE44734EB7990E
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV IOJS_VERSION 2.0.1
+ENV IOJS_VERSION 2.0.2
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \

--- a/2.0/onbuild/Dockerfile
+++ b/2.0/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM iojs:2.0.1
+FROM iojs:2.0.2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/2.0/slim/Dockerfile
+++ b/2.0/slim/Dockerfile
@@ -7,7 +7,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   FD3A5288F042B6850C66B31F09FE44734EB7990E
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV IOJS_VERSION 2.0.1
+ENV IOJS_VERSION 2.0.2
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
This PR updates io.js to version 2.0.2.

Related: nodejs/io.js#1679
