### PR TITLE
Nominating Christopher Horrell @chorrell to the Docker WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Support for older versions (down to 1.0) is provided on a best-effort basis.
 
 Current Project Team Members:
 
+ * [@chorrell](https://github.com/chorrell)
  * [@hmalphettes](https://www.github.com/hmalphettes)
  * [@jlmitch5](https://www.github.com/jlmitch5)
  * [@pesho](https://www.github.com/pesho)


### PR DESCRIPTION
In #58 @pesho brought up that Christopher should be invited to the Docker Working Group, and I could not agree more! I reached out to Christopher, and [he replied positively](https://twitter.com/chorrell/status/600031685477011457) when I asked if he would like to join the Docker Working Group.

For those who do not know Christopher, he works as Solutions Engineering Manager at Joyent and has been maintaining the official [`node` Docker image](https://registry.hub.docker.com/_/node/) @ [joyent/docker-node](https://joyent/docker-node/). Christopher has a lot of experience with maintaining and testing container images and I believe he will be a valuable addition to the Working Group.
