### PR TITLE
Rename GitHub organization from `iojs` to `nodejs`.

### DIFF
--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:jessie
 
-# gpg keys listed at https://github.com/iojs/io.js
+# gpg keys listed at https://github.com/nodejs/io.js
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   9554F04D7259F04124DE6B476D5A82AC7E37093B \
   DD8F2338BAE7501E3DD5AC78C273792F7D83545D \

--- a/1.8/slim/Dockerfile
+++ b/1.8/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:jessie-curl
 
-# gpg keys listed at https://github.com/iojs/io.js
+# gpg keys listed at https://github.com/nodejs/io.js
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   9554F04D7259F04124DE6B476D5A82AC7E37093B \
   DD8F2338BAE7501E3DD5AC78C273792F7D83545D \

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:jessie
 
-# gpg keys listed at https://github.com/iojs/io.js
+# gpg keys listed at https://github.com/nodejs/io.js
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   9554F04D7259F04124DE6B476D5A82AC7E37093B \
   DD8F2338BAE7501E3DD5AC78C273792F7D83545D \

--- a/2.0/slim/Dockerfile
+++ b/2.0/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:jessie-curl
 
-# gpg keys listed at https://github.com/iojs/io.js
+# gpg keys listed at https://github.com/nodejs/io.js
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   9554F04D7259F04124DE6B476D5A82AC7E37093B \
   DD8F2338BAE7501E3DD5AC78C273792F7D83545D \

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -19,7 +19,7 @@ For the current list of WG members, see the project
 
 ## Collaborators
 
-The [iojs/docker-iojs](https://github.com/iojs/docker-iojs) GitHub repository is
+The [nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) GitHub repository is
 maintained by the WG and additional Collaborators who are added by the
 WG on an ongoing basis.
 
@@ -32,7 +32,7 @@ Collaborators is discussed as a pull request to this project's
 _Note:_ If you make a significant contribution and are not considered
 for commit-access log an issue or contact a WG member directly.
 
-Modifications of the contents of the iojs/docker-iojs repository are made on
+Modifications of the contents of the nodejs/docker-iojs repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a
 modification via pull request and it will be considered by the project
 Collaborators. All pull requests must be reviewed and accepted by a
@@ -67,7 +67,7 @@ The WG may add additional members to the WG by unanimous consensus.
 
 A WG member may be removed from the WG by voluntary resignation, or by
 unanimous consensus of all other WG members in an issue or pull request
-on the [iojs/docker-iojs](https://github.com/iojs/docker-iojs) repository
+on the [nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) repository
 
 No more than 1/3 of the WG members may be affiliated with the same
 employer. If removal or resignation of a WG member, or a change of
@@ -79,7 +79,7 @@ members affiliated with the over-represented employer(s).
 ## WG Meetings
 
 This working group does not meet. All discussions and decisions happen
-in the [iojs/docker-iojs](https://github.com/iojs/docker-iojs) repository
+in the [nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) repository
 in issues and pull requests. Items can be flagged as needing a board
 decision by **WG-agenda** tag to the issue.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![dockeri.co](http://dockeri.co/image/_/iojs)](https://registry.hub.docker.com/_/iojs/)
 
-[![GitHub issues](https://img.shields.io/github/issues/iojs/docker-iojs.svg "GitHub issues")](https://github.com/iojs/docker-iojs)
-[![GitHub stars](https://img.shields.io/github/stars/iojs/docker-iojs.svg "GitHub stars")](https://github.com/iojs/docker-iojs)
+[![GitHub issues](https://img.shields.io/github/issues/nodejs/docker-iojs.svg "GitHub issues")](https://github.com/nodejs/docker-iojs)
+[![GitHub stars](https://img.shields.io/github/stars/nodejs/docker-iojs.svg "GitHub stars")](https://github.com/nodejs/docker-iojs)
 
 The official iojs docker image, made with love by the iojs community.
 
@@ -84,9 +84,9 @@ repository.
 
 # License
 
-[License information](https://github.com/iojs/io.js/blob/master/LICENSE) for
+[License information](https://github.com/nodejs/io.js/blob/master/LICENSE) for
 the software contained in this image. [License
-information](https://github.com/iojs/docker-iojs/blob/master/LICENSE) for the
+information](https://github.com/nodejs/docker-iojs/blob/master/LICENSE) for the
 io.js Docker project.
 
 # Supported Docker versions

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -11,9 +11,9 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-url='git://github.com/iojs/docker-iojs'
+url='git://github.com/nodejs/docker-iojs'
 
-echo '# maintainer: io.js Docker team <https://github.com/iojs/docker-iojs> (@iojs)'
+echo '# maintainer: io.js Docker team <https://github.com/nodejs/docker-iojs> (@iojs)'
 
 for version in "${versions[@]}"; do
 	commit="$(git log -1 --format='format:%H' -- "$version")"


### PR DESCRIPTION
The GH organization was renamed after the io.js project decided to join the Node Foundation. This PR updates the relevant links to reflect that change.

Note that the current situation is temporary. After the first converged io.js/Node.js release this repository will likely be renamed, which will require the links to be updated again.
