### PR TITLE
Update GOVERNANCE policy from upstream

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,9 +1,7 @@
-# io.js Project Governance
+# Docker Working Group
 
-## Working Group
-
-The io.js docker project is jointly governed by a Working Group (WG)
-which is responsible for high-level guidance of the project.
+The io.js Docker project is jointly governed by a Working Group (WG)
+that is responsible for high-level guidance of the project.
 
 The WG has final authority over this project including:
 
@@ -19,12 +17,12 @@ For the current list of WG members, see the project
 
 ## Collaborators
 
-The [nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) GitHub repository is
-maintained by the WG and additional Collaborators who are added by the
-WG on an ongoing basis.
+The [nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) GitHub
+repository is maintained by the WG and additional Collaborators who
+are added by the WG on an ongoing basis.
 
 Individuals making significant and valuable contributions are made
-Collaborators and given commit-access to the project. These
+Collaborators and given commit-access to the project.  These
 individuals are identified by the WG and their addition as
 Collaborators is discussed as a pull request to this project's
 [README.md](./README.md#people).
@@ -32,22 +30,23 @@ Collaborators is discussed as a pull request to this project's
 _Note:_ If you make a significant contribution and are not considered
 for commit-access log an issue or contact a WG member directly.
 
-Modifications of the contents of the nodejs/docker-iojs repository are made on
-a collaborative basis. Anybody with a GitHub account may propose a
-modification via pull request and it will be considered by the project
-Collaborators. All pull requests must be reviewed and accepted by a
-Collaborator with sufficient expertise who is able to take full
-responsibility for the change. In the case of pull requests proposed
-by an existing Collaborator, an additional Collaborator is required
-for sign-off. Consensus should be sought if additional Collaborators
-participate and there is disagreement around a particular
-modification. See _Consensus Seeking Process_ below for further detail
-on the consensus model used for governance.
+Modifications of the contents of the
+[nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) repository
+are made on a collaborative basis.  Anybody with a GitHub account may
+propose a modification via pull request and it will be considered by
+the project Collaborators.  All pull requests must be reviewed and
+accepted by a Collaborator with sufficient expertise who is able to
+take full responsibility for the change.  In the case of pull requests
+proposed by an existing Collaborator, an additional Collaborator is
+required for sign-off.  Consensus should be sought if additional
+Collaborators participate and there is disagreement around a
+particular modification.  See _Consensus Seeking Process_ below for
+further detail on the consensus model used for governance.
 
 Collaborators may opt to elevate significant or controversial
 modifications, or modifications that have not found consensus to the
-WG for discussion by assigning the ***WG-agenda*** tag to a pull
-request or issue. The WG should serve as the final arbiter where
+WG for discussion by assigning the ***WG-agenda*** label to a pull
+request or issue.  The WG should serve as the final arbiter where
 required.
 
 For the current list of Collaborators, see the project
@@ -55,7 +54,7 @@ For the current list of Collaborators, see the project
 
 ## WG Membership
 
-WG seats are not time-limited. There is no fixed size of the WG.
+WG seats are not time-limited.  There is no fixed size of the WG.
 However, the expected target is between 6 and 12, to ensure adequate
 coverage of important areas of expertise, balanced with the ability to
 make decisions efficiently.
@@ -63,14 +62,16 @@ make decisions efficiently.
 There is no specific set of requirements or qualifications for WG
 membership beyond these rules.
 
-The WG may add additional members to the WG by unanimous consensus.
+The WG may add, or remove, members to and from the WG. A WG member may
+choose to be removed from the WG by voluntary resignation.
 
-A WG member may be removed from the WG by voluntary resignation, or by
-unanimous consensus of all other WG members in an issue or pull request
-on the [nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) repository
+Changes to WG membership should be posted in the
+[nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) repository
+as an issue or pull request with the ***WG-agenda*** label followed by
+the consensus seeking process described below.
 
 No more than 1/3 of the WG members may be affiliated with the same
-employer. If removal or resignation of a WG member, or a change of
+employer.  If removal or resignation of a WG member, or a change of
 employment by a WG member, creates a situation where more than 1/3 of
 the WG membership shares an employer, then the situation must be
 immediately remedied by the resignation or removal of one or more WG
@@ -78,36 +79,96 @@ members affiliated with the over-represented employer(s).
 
 ## WG Meetings
 
-This working group does not meet. All discussions and decisions happen
-in the [nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) repository
-in issues and pull requests. Items can be flagged as needing a board
-decision by **WG-agenda** tag to the issue.
+This working group does not meet.  All discussions and decisions
+happen in the
+[nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) repository
+in issues and pull requests.  Items that requires a decission by the
+WG can be flagged with the ***WG-agenda*** label.
 
-When an issue is tagged with **WG-agenda**, The WG may invite persons or
-representatives from certain projects to participate in the discussion in
-a non-voting capacity.
+When an issue is tagged with ***WG-agenda***, the WG may invite
+persons or representatives from certain projects to participate in the
+discussion in a non-voting capacity.
 
 ## Consensus Seeking Process
 
-The WG follows a
-[Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
-decision making model.
+The WG follows a [Consensus
+Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
+decision-making model.
 
-All proposed changes to the project must be made in the form
-of a pull request to the repository (directly commiting to a production
-branch of the repository is not permitted). The consensus seeking process
-will then follow via discussion by the WG members on that pull request.
-Changes deemed trivial by WG members may be merged instantly by any
-WG member, without waiting for consensus, so long as they leave  a note
-explaining the reason for the merge.
+All proposed changes to the project must be made in the form of a pull
+request to the repository (directly commiting to a production branch
+of the repository is not permitted).  The consensus seeking process
+will then follow via discussion by the WG members on that pull
+request.  Changes deemed trivial by WG members may be merged instantly
+by any WG member, without waiting for consensus, so long as they leave
+a note explaining the reason for the merge.
 
-When an agenda item has appeared to reach a consensus the moderator
-will ask "Does anyone object?" as a final call for dissent from the
+When an agenda item has appeared to reach a consensus any WG member
+may ask "Does anyone object?" as a final call for dissent from the
 consensus.
 
-If an agenda item cannot reach a consensus a WG member can call for
-a closing vote. The call for a vote must be seconded by a majority of the WG
-or else the discussion will continue. Simple majority wins.
+If an agenda item cannot reach a consensus a WG member can call for a
+closing vote.  The call for a vote must be seconded by a majority of
+the WG or else the discussion will continue.  Simple majority wins.
 
-Note that changes to WG membership require unanimous consensus. See
-"WG Membership" above.
+## Developer's Certificate of Origin 1.0
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license indicated
+  in the file; or
+
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source license
+  and I have the right under that license to submit that work with
+  modifications, whether created in whole or in part by me, under the
+  same open source license (unless I am permitted to submit under a
+  different license), as indicated in the file; or
+
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified it.
+
+## Code of Conduct
+
+This Code of Conduct is adapted from [Rust's wonderful
+CoC](https://github.com/rust-lang/rust/wiki/Note-development-policy#conduct).
+
+* We are committed to providing a friendly, safe and welcoming
+  environment for all, regardless of gender, sexual orientation,
+  disability, ethnicity, religion, or similar personal characteristic.
+
+* Please avoid using overtly sexual nicknames or other nicknames that
+  might detract from a friendly, safe and welcoming environment for
+  all.
+
+* Please be kind and courteous.  There's no need to be mean or rude.
+* Respect that people have differences of opinion and that every
+  design or implementation choice carries a trade-off and numerous
+  costs.  There is seldom a right answer.
+
+* Please keep unstructured critique to a minimum.  If you have solid
+  ideas you want to experiment with, make a fork and see how it works.
+
+* We will exclude you from interaction if you insult, demean or harass
+  anyone.  That is not welcome behaviour.  We interpret the term
+  "harassment" as including the definition in the [Citizen Code of
+  Conduct](http://citizencodeofconduct.org/); if you have any lack of
+  clarity about what might be included in that concept, please read
+  their definition.  In particular, we don't tolerate behavior that
+  excludes people in socially marginalized groups.
+
+* Private harassment is also unacceptable.  No matter who you are, if
+  you feel you have been or are being harassed or made uncomfortable
+  by a community member, please contact one of the channel ops or any
+  of the TC members immediately with a capture (log, photo, email) of
+  the harassment if possible.  Whether you're a regular contributor or
+  a newcomer, we care about making this community a safe place for you
+  and we've got your back.
+
+* Likewise any spamming, trolling, flaming, baiting or other
+  attention-stealing behaviour is not welcome.
+
+* Avoid the use of personal pronouns in code comments or
+  documentation.  There is no need to address persons when explaining
+  code (e.g. "When the developer")


### PR DESCRIPTION
**Notable changes:**
- Document updated from upstream [Working Group Bootstrap Governance](https://github.com/nodejs/io.js/blob/master/WORKING_GROUPS.md#bootstrap-governance)
- Added Developer's Certificate of Origin 1.0
- Added Code of Conduct
- Changes to the WG membership follows standard consensus seeking process

```
The WG may add additional members to the WG by unanimous consensus.

A WG member may be removed from the WG by voluntary resignation, or by
unanimous consensus of all other WG members in an issue or pull request
on the [nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) repository
```

Has been replaced with 

```
The WG may add, or remove, members to and from the WG. A WG member may
be choose to be removed from the WG by voluntary resignation.

Changes to WG membership should be posted in the
[nodejs/docker-iojs](https://github.com/nodejs/docker-iojs) repository
as an issue or pull request with the ***WG-agenda*** label followed by
the consensus seeking process described below.
```
