### PR TITLE
Update io.js 2.x to v2.3.1

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -7,7 +7,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   FD3A5288F042B6850C66B31F09FE44734EB7990E
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV IOJS_VERSION 2.3.0
+ENV IOJS_VERSION 2.3.1
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \

--- a/2.3/onbuild/Dockerfile
+++ b/2.3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM iojs:2.3.0
+FROM iojs:2.3.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/2.3/slim/Dockerfile
+++ b/2.3/slim/Dockerfile
@@ -7,7 +7,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   FD3A5288F042B6850C66B31F09FE44734EB7990E
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV IOJS_VERSION 2.3.0
+ENV IOJS_VERSION 2.3.1
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
This PR updates io.js 2.x Docker images to v2.3.1.

Related: nodejs/io.js#1996
Signed-off-by: Hans Kristian Flaatten hans.kristian.flaatten@turistforeningen.no
