### PR TITLE
Update io.js 1.x to v1.8.3

### DIFF
--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -7,7 +7,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   FD3A5288F042B6850C66B31F09FE44734EB7990E
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV IOJS_VERSION 1.8.2
+ENV IOJS_VERSION 1.8.3
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \

--- a/1.8/onbuild/Dockerfile
+++ b/1.8/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM iojs:1.8.2
+FROM iojs:1.8.3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/1.8/slim/Dockerfile
+++ b/1.8/slim/Dockerfile
@@ -7,7 +7,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
   FD3A5288F042B6850C66B31F09FE44734EB7990E
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV IOJS_VERSION 1.8.2
+ENV IOJS_VERSION 1.8.3
 
 RUN curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/iojs-v$IOJS_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://iojs.org/dist/v$IOJS_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
This PR updates the 1.8 io.js Docker Image to v1.8.3.

Realted: nodejs/io.js#1703
Signed-off-by: Hans Kristian Flaatten hans.kristian.flaatten@turistforeningen.no
